### PR TITLE
feat: Vercel 배포 워크플로우 추가 및 프로덕션/프리뷰 환경 분리 #64

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,30 +1,44 @@
-name: deploy
+name: Deploy to Vercel
 
 on:
   push:
-    branches:
-      - main
-      - stage
-  pull_request:
-    branches:
-      - main
-      - stage
-    types: [opened, synchronize, reopened]
-
-permissions:
-  deployments: write
-  pull-requests: write
+    branches: [main, stage]
 
 jobs:
-  deploy:
+  deploy-production:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: mountainash/deploy-to-vercel-action@v2.5.0
+      - name: Deploy to Vercel (Production)
+        uses: mountainash/deploy-to-vercel-action@v2.5.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          PRODUCTION: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          PRODUCTION: true
+          ALIAS_DOMAINS: eatda.net
+          GITHUB_DEPLOYMENT: true
+          GITHUB_DEPLOYMENT_ENV: Production
+
+  deploy-preview:
+    if: github.ref == 'refs/heads/stage'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to Vercel (Preview)
+        uses: mountainash/deploy-to-vercel-action@v2.5.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          PRODUCTION: false
+          ALIAS_DOMAINS: dev.eatda.net
+          GITHUB_DEPLOYMENT: true
+          GITHUB_DEPLOYMENT_ENV: Preview


### PR DESCRIPTION
## ✅ 이슈 번호

close #64 

<br>

## 🪄 작업 내용 (변경 사항)

- [x] production / stage 분리하는 작업

<br>

## 📸 스크린샷

<br>

## 💡 설명

<br>

## 🗣️ 리뷰어에게 전달 사항

제발 되길 바라며 머지 해볼까요?

<br>

## 📍 트러블 슈팅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions 배포 워크플로우 이름이 "Deploy to Vercel"로 변경되었습니다.
  * 배포 워크플로우가 production과 preview로 분리되어 각각 main 및 stage 브랜치에만 동작하도록 개선되었습니다.
  * 각 배포 작업의 단계가 명확하게 지정되고, 배포 환경 및 도메인 설정이 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->