### PR TITLE
ci: 배포 워크플로우에서 stage 배포 및 ALIAS_DOMAINS 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to Vercel
 
 on:
   push:
-    branches: [main, stage]
+    branches: [main]
 
 jobs:
   deploy-production:
@@ -20,25 +20,5 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           PRODUCTION: true
-          ALIAS_DOMAINS: eatda.net
           GITHUB_DEPLOYMENT: true
           GITHUB_DEPLOYMENT_ENV: Production
-
-  deploy-preview:
-    if: github.ref == 'refs/heads/stage'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Deploy to Vercel (Preview)
-        uses: mountainash/deploy-to-vercel-action@v2.5.0
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          PRODUCTION: false
-          ALIAS_DOMAINS: dev.eatda.net
-          GITHUB_DEPLOYMENT: true
-          GITHUB_DEPLOYMENT_ENV: Preview


### PR DESCRIPTION
## ✅ 이슈 번호

close #70 

<br>

## 🪄 작업 내용 (변경 사항)

- [x] 어떻게든 무료로 잘 써보려고 했던 노력들이 물거품되고 잘 안 되던 테스트 배포 워크플로우 제거

<br>

## 📸 스크린샷

<br>

## 💡 설명

<br>

## 🗣️ 리뷰어에게 전달 사항

<br>

## 📍 트러블 슈팅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Vercel 배포 워크플로우가 main 브랜치에만 동작하도록 변경되었습니다.
  * stage 브랜치에서의 프리뷰 배포가 더 이상 제공되지 않습니다.
  * 프로덕션 배포 환경 변수 일부가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->