### PR TITLE
feat: AlertModal 컴포넌트 생성 (#87)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.14",
     "@hookform/resolvers": "^5.1.1",
     "@tanstack/react-query": "^5.77.0",
     "@tanstack/react-query-devtools": "^5.77.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@radix-ui/react-dialog": "^1.1.14",
     "@hookform/resolvers": "^5.1.1",
+    "@radix-ui/react-alert-dialog": "^1.1.14",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@tanstack/react-query": "^5.77.0",
     "@tanstack/react-query-devtools": "^5.77.0",
     "@use-funnel/browser": "^0.0.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.1.1
         version: 5.1.1(react-hook-form@7.59.0(react@19.1.0))
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.14
+        version: 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1569,6 +1572,19 @@ packages:
 
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
+
+  '@radix-ui/react-alert-dialog@1.1.14':
+    resolution: {integrity: sha512-IOZfZ3nPvN6lXpJTBCunFQPRSvK8MDgSc1FB85xnIpUKOw9en0dJj8JmCAxV7BiZdtYlUpmrQjoTFkVYtdoWzQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -7581,6 +7597,20 @@ snapshots:
   '@polka/url@1.0.0-next.29': {}
 
   '@radix-ui/primitive@1.1.2': {}
+
+  '@radix-ui/react-alert-dialog@1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.5)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.5
+      '@types/react-dom': 19.1.5(@types/react@19.1.5)
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.5)(react@19.1.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.1.1
         version: 5.1.1(react-hook-form@7.59.0(react@19.1.0))
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.14
+        version: 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tanstack/react-query':
         specifier: ^5.77.0
         version: 5.77.0(react@19.1.0)

--- a/src/components/ui/AlertModal/AlertModal.css.ts
+++ b/src/components/ui/AlertModal/AlertModal.css.ts
@@ -24,7 +24,7 @@ export const content = style({
   zIndex: zIndex.modal,
 });
 
-export const textWrapper = style({
+export const innerContent = style({
   overflowY: "auto",
   padding: "4.8rem 1.6rem",
   display: "flex",
@@ -41,21 +41,19 @@ export const description = style({
   ...typography.body2Rg,
   color: semantic.text.alternative,
   marginTop: "0.8rem",
+  width: "100%",
+  textAlign: "center",
 });
 
-export const buttonGroup = style({
-  display: "flex",
+export const footer = style({
   width: "100%",
+  display: "flex",
 });
 
 export const cancelButton = style({
   flex: 1,
-  minWidth: 0,
-  overflow: "hidden",
 });
 
 export const confirmButton = style({
   flex: 1,
-  minWidth: 0,
-  overflow: "hidden",
 });

--- a/src/components/ui/AlertModal/AlertModal.css.ts
+++ b/src/components/ui/AlertModal/AlertModal.css.ts
@@ -1,0 +1,61 @@
+import { style } from "@vanilla-extract/css";
+
+import { radius, semantic, typography } from "@/styles";
+import { zIndex } from "@/styles/zIndex.css";
+
+export const overlay = style({
+  position: "fixed",
+  inset: 0,
+  backgroundColor: semantic.background.dim,
+  zIndex: zIndex.overlay,
+});
+
+export const content = style({
+  maxHeight: "80vh",
+  display: "flex",
+  flexDirection: "column",
+  position: "fixed",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: "min(30rem, 90vw)",
+  background: semantic.background.white,
+  borderRadius: radius[120],
+  zIndex: zIndex.modal,
+});
+
+export const textWrapper = style({
+  overflowY: "auto",
+  padding: "4.8rem 1.6rem",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+});
+
+export const title = style({
+  ...typography.title3Sb,
+  color: semantic.text.normal,
+});
+
+export const description = style({
+  ...typography.body2Rg,
+  color: semantic.text.alternative,
+  marginTop: "0.8rem",
+});
+
+export const buttonGroup = style({
+  display: "flex",
+  width: "100%",
+});
+
+export const cancelButton = style({
+  flex: 1,
+  minWidth: 0,
+  overflow: "hidden",
+});
+
+export const confirmButton = style({
+  flex: 1,
+  minWidth: 0,
+  overflow: "hidden",
+});

--- a/src/components/ui/AlertModal/AlertModal.stories.tsx
+++ b/src/components/ui/AlertModal/AlertModal.stories.tsx
@@ -1,29 +1,39 @@
+import * as AlertDialog from "@radix-ui/react-alert-dialog";
 import type { Meta, StoryObj } from "@storybook/nextjs";
-import { useState } from "react";
 
 import { Button } from "../Button";
-import { AlertModal, type AlertModalProps } from "./AlertModal";
+import { AlertModal } from "./AlertModal";
+import * as styles from "./AlertModal.css";
 
 const meta: Meta<typeof AlertModal> = {
   title: "Components/AlertModal",
   component: AlertModal,
   tags: ["autodocs"],
   argTypes: {
-    open: { control: false },
-    onOpenChange: { control: false },
-    title: { control: "text", description: "모달의 타이틀" },
-    description: { control: "text", description: "모달의 서브 설명" },
-    confirmLabel: { control: "text", description: "확인 버튼 라벨" },
-    cancelLabel: { control: "text", description: "취소 버튼 라벨" },
-    onConfirm: { action: "onConfirm", description: "확인 버튼 클릭 시 콜백" },
-    onCancel: { action: "onCancel", description: "취소 버튼 클릭 시 콜백" },
+    title: {
+      control: "text",
+      description: "모달의 제목",
+    },
+    trigger: {
+      control: false,
+      description: "모달을 열기 위한 트리거(버튼 등, ReactNode)",
+    },
+    content: {
+      control: false,
+      description: "본문(설명 등, ReactNode)",
+    },
+    footer: {
+      control: false,
+      description:
+        "하단 푸터(버튼 영역 등, ReactNode). Radix의 <AlertDialog.Cancel asChild> 또는 <AlertDialog.Action asChild>를 조합하여 사용.",
+    },
   },
   parameters: {
     layout: "centered",
     docs: {
       description: {
         component:
-          "AlertModal은 사용자에게 확인/취소 액션을 요청할 때 사용하는 모달입니다. title, description, confirmLabel, cancelLabel, onConfirm, onCancel 등을 지원합니다.",
+          "AlertModal은 사용자에게 확인/취소 액션을 요청할 때 사용하는 모달입니다. title, trigger, content, footer props를 지원합니다.",
       },
     },
   },
@@ -32,24 +42,34 @@ const meta: Meta<typeof AlertModal> = {
 export default meta;
 type Story = StoryObj<typeof AlertModal>;
 
-const AlertModalTemplate = (args: Partial<AlertModalProps>) => {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <>
-      <Button onClick={() => setOpen(true)}>모달 열기</Button>
-      <AlertModal {...args} open={open} onOpenChange={setOpen} />
-    </>
-  );
-};
-
 export const Default: Story = {
-  render: args => <AlertModalTemplate {...args} />,
+  render: args => <AlertModal {...args} />,
   args: {
     title: "정말 삭제하시겠어요?",
-    description: "삭제 후에는 복구할 수 없습니다.",
-    confirmLabel: "삭제",
-    cancelLabel: "취소",
+    trigger: <Button>모달 열기</Button>,
+    content: <div>삭제하면 복구할 수 없습니다.</div>,
+    footer: (
+      <>
+        <AlertDialog.Cancel asChild>
+          <Button
+            variant='assistive'
+            className={styles.cancelButton}
+            style={{ borderRadius: "0 0 0 1.2rem" }}
+          >
+            취소
+          </Button>
+        </AlertDialog.Cancel>
+        <AlertDialog.Action asChild>
+          <Button
+            variant='primary'
+            className={styles.confirmButton}
+            style={{ borderRadius: "0 0 1.2rem 0" }}
+          >
+            삭제
+          </Button>
+        </AlertDialog.Action>
+      </>
+    ),
   },
   parameters: {
     docs: {
@@ -62,62 +82,37 @@ export const Default: Story = {
 };
 
 export const NoDescription: Story = {
-  render: args => <AlertModalTemplate {...args} />,
+  render: args => <AlertModal {...args} />,
   args: {
     title: "약관을 동의하시겠습니까?",
-    confirmLabel: "동의",
-    cancelLabel: "취소",
+    trigger: <Button>모달 열기</Button>,
+    footer: (
+      <>
+        <AlertDialog.Cancel asChild>
+          <Button
+            variant='assistive'
+            className={styles.cancelButton}
+            style={{ borderRadius: "0 0 0 1.2rem" }}
+          >
+            취소
+          </Button>
+        </AlertDialog.Cancel>
+        <AlertDialog.Action asChild>
+          <Button
+            variant='primary'
+            className={styles.confirmButton}
+            style={{ borderRadius: "0 0 1.2rem 0" }}
+          >
+            동의
+          </Button>
+        </AlertDialog.Action>
+      </>
+    ),
   },
   parameters: {
     docs: {
       description: {
         story: "description 없이 타이틀과 버튼만 표시되는 AlertModal입니다.",
-      },
-    },
-  },
-};
-
-export const AsyncConfirm: Story = {
-  render: args => {
-    const AsyncTemplate = () => {
-      const [open, setOpen] = useState(false);
-      const [loading, setLoading] = useState(false);
-
-      const handleConfirm = async () => {
-        setLoading(true);
-        await new Promise(res => setTimeout(res, 1500));
-        setLoading(false);
-        setOpen(false);
-        alert("비동기 작업 완료!");
-      };
-
-      return (
-        <>
-          <Button onClick={() => setOpen(true)}>모달 열기</Button>
-          <AlertModal
-            {...args}
-            open={open}
-            onOpenChange={setOpen}
-            onConfirm={handleConfirm}
-            confirmLabel={loading ? "처리 중..." : args.confirmLabel}
-          />
-        </>
-      );
-    };
-
-    return <AsyncTemplate />;
-  },
-  args: {
-    title: "비동기 확인 예시",
-    description: "확인 버튼 클릭 시 비동기 작업을 실행합니다.",
-    confirmLabel: "확인",
-    cancelLabel: "취소",
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "확인 버튼 클릭 시 비동기 작업을 수행하는 AlertModal 예시입니다. 버튼 라벨이 로딩 상태로 변경됩니다.",
       },
     },
   },

--- a/src/components/ui/AlertModal/AlertModal.stories.tsx
+++ b/src/components/ui/AlertModal/AlertModal.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { useState } from "react";
+
+import { Button } from "../Button";
+import { AlertModal, type AlertModalProps } from "./AlertModal";
+
+const meta: Meta<typeof AlertModal> = {
+  title: "Components/AlertModal",
+  component: AlertModal,
+  tags: ["autodocs"],
+  argTypes: {
+    open: { control: false },
+    onOpenChange: { control: false },
+    title: { control: "text", description: "모달의 타이틀" },
+    description: { control: "text", description: "모달의 서브 설명" },
+    confirmLabel: { control: "text", description: "확인 버튼 라벨" },
+    cancelLabel: { control: "text", description: "취소 버튼 라벨" },
+    onConfirm: { action: "onConfirm", description: "확인 버튼 클릭 시 콜백" },
+    onCancel: { action: "onCancel", description: "취소 버튼 클릭 시 콜백" },
+  },
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "AlertModal은 사용자에게 확인/취소 액션을 요청할 때 사용하는 모달입니다. title, description, confirmLabel, cancelLabel, onConfirm, onCancel 등을 지원합니다.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AlertModal>;
+
+const AlertModalTemplate = (args: Partial<AlertModalProps>) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>모달 열기</Button>
+      <AlertModal {...args} open={open} onOpenChange={setOpen} />
+    </>
+  );
+};
+
+export const Default: Story = {
+  render: args => <AlertModalTemplate {...args} />,
+  args: {
+    title: "정말 삭제하시겠어요?",
+    description: "삭제 후에는 복구할 수 없습니다.",
+    confirmLabel: "삭제",
+    cancelLabel: "취소",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "기본 AlertModal. 타이틀과 설명, 확인/취소 버튼을 모두 포함합니다.",
+      },
+    },
+  },
+};
+
+export const NoDescription: Story = {
+  render: args => <AlertModalTemplate {...args} />,
+  args: {
+    title: "약관을 동의하시겠습니까?",
+    confirmLabel: "동의",
+    cancelLabel: "취소",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "description 없이 타이틀과 버튼만 표시되는 AlertModal입니다.",
+      },
+    },
+  },
+};
+
+export const AsyncConfirm: Story = {
+  render: args => {
+    const AsyncTemplate = () => {
+      const [open, setOpen] = useState(false);
+      const [loading, setLoading] = useState(false);
+
+      const handleConfirm = async () => {
+        setLoading(true);
+        await new Promise(res => setTimeout(res, 1500));
+        setLoading(false);
+        setOpen(false);
+        alert("비동기 작업 완료!");
+      };
+
+      return (
+        <>
+          <Button onClick={() => setOpen(true)}>모달 열기</Button>
+          <AlertModal
+            {...args}
+            open={open}
+            onOpenChange={setOpen}
+            onConfirm={handleConfirm}
+            confirmLabel={loading ? "처리 중..." : args.confirmLabel}
+          />
+        </>
+      );
+    };
+
+    return <AsyncTemplate />;
+  },
+  args: {
+    title: "비동기 확인 예시",
+    description: "확인 버튼 클릭 시 비동기 작업을 실행합니다.",
+    confirmLabel: "확인",
+    cancelLabel: "취소",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "확인 버튼 클릭 시 비동기 작업을 수행하는 AlertModal 예시입니다. 버튼 라벨이 로딩 상태로 변경됩니다.",
+      },
+    },
+  },
+};

--- a/src/components/ui/AlertModal/AlertModal.tsx
+++ b/src/components/ui/AlertModal/AlertModal.tsx
@@ -1,108 +1,75 @@
-import type { DialogProps } from "@radix-ui/react-dialog";
-import * as Dialog from "@radix-ui/react-dialog";
+import * as AlertDialog from "@radix-ui/react-alert-dialog";
+import { type ReactNode } from "react";
 
-import { Button } from "../Button";
 import * as styles from "./AlertModal.css";
 
 export type AlertModalProps = {
-  /** 모달 제목  */
+  /** 모달의 제목 */
   title?: string;
 
-  /** 모달 설명  */
-  description?: string;
+  /** 모달을 열기 위한 트리거(버튼 등, 선택) */
+  trigger?: ReactNode;
 
-  /** 확인 버튼 클릭 시 실행되는 콜백 */
-  onConfirm?: () => void | Promise<void>;
+  /** 본문(설명 등, ReactNode로 자유롭게 구성) */
+  content?: ReactNode;
 
-  /** 취소 버튼 클릭 시 실행되는 콜백 */
-  onCancel?: () => void;
-
-  /** 확인 버튼 텍스트 */
-  confirmLabel?: string;
-
-  /** 취소 버튼 텍스트 */
-  cancelLabel?: string;
-} & DialogProps;
+  /**
+   * 하단 푸터(버튼 영역 등, ReactNode로 자유롭게 구성)
+   * Radix의 <AlertDialog.Cancel asChild> 또는 <AlertDialog.Action asChild>를 조합하여 사용 가능
+   * 예시:
+   * <>
+   *   <AlertDialog.Cancel asChild>
+   *     <Button>취소</Button>
+   *   </AlertDialog.Cancel>
+   *   <AlertDialog.Action asChild>
+   *     <Button>확인</Button>
+   *   </AlertDialog.Action>
+   * </>
+   */
+  footer?: ReactNode;
+};
 
 /**
  * AlertModal 컴포넌트
  *
- * @description
- * Radix UI의 Dialog를 래핑한 모달 컴포넌트입니다.
- * 제목과 설명을 표시하고, 확인/취소 버튼을 제공합니다.
- *
  * @example
  * ```tsx
- * const [open, setOpen] = useState(false);
- *
  * <AlertModal
- *   open={open}
- *   onOpenChange={setOpen}
- *   title="로그아웃 하시겠어요?"
- *   description="로그아웃하면 다시 로그인해야 합니다."
- *   cancelLabel="취소"
- *   confirmLabel="로그아웃"
- *   onCancel={() => console.log("취소")}
- *   onConfirm={() => console.log("확인")}
+ *   title="정말 삭제하시겠어요?"
+ *   trigger={<Button>모달 열기</Button>}
+ *   content={<div>삭제하면 복구할 수 없습니다.</div>}
+ *   footer={
+ *     <>
+ *       <Button variant="assistive">취소</Button>
+ *       <Button variant="primary">삭제</Button>
+ *     </>
+ *   }
  * />
  * ```
  */
 export const AlertModal = ({
-  open,
-  onOpenChange,
   title,
-  description,
-  onConfirm,
-  onCancel,
-  confirmLabel = "확인",
-  cancelLabel = "취소",
+  trigger,
+  content,
+  footer,
 }: AlertModalProps) => {
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay className={styles.overlay} />
-        <Dialog.Content className={styles.content}>
-          {(title || description) && (
-            <div className={styles.textWrapper}>
-              {title && (
-                <Dialog.Title className={styles.title}>{title}</Dialog.Title>
-              )}
-              {description && (
-                <Dialog.Description className={styles.description}>
-                  {description}
-                </Dialog.Description>
-              )}
-            </div>
-          )}
-
-          <div className={styles.buttonGroup}>
-            <Dialog.Close asChild>
-              <Button
-                className={styles.cancelButton}
-                variant='assistive'
-                size='large'
-                onClick={onCancel}
-                style={{
-                  borderRadius: "0 0 0 1.2rem",
-                }}
-              >
-                {cancelLabel}
-              </Button>
-            </Dialog.Close>
-            <Button
-              className={styles.confirmButton}
-              variant='primary'
-              size='large'
-              onClick={onConfirm}
-              style={{
-                borderRadius: "0 0 1.2rem 0",
-              }}
-            >
-              {confirmLabel}
-            </Button>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+    <AlertDialog.Root>
+      {trigger && <AlertDialog.Trigger asChild>{trigger}</AlertDialog.Trigger>}
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay className={styles.overlay} />
+        <AlertDialog.Content className={styles.content}>
+          <section className={styles.innerContent}>
+            {title && (
+              <AlertDialog.Title className={styles.title}>
+                {title}
+              </AlertDialog.Title>
+            )}
+            {content && <div className={styles.description}>{content}</div>}
+          </section>
+          {footer && <div className={styles.footer}>{footer}</div>}
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
   );
 };

--- a/src/components/ui/AlertModal/AlertModal.tsx
+++ b/src/components/ui/AlertModal/AlertModal.tsx
@@ -1,0 +1,108 @@
+import type { DialogProps } from "@radix-ui/react-dialog";
+import * as Dialog from "@radix-ui/react-dialog";
+
+import { Button } from "../Button";
+import * as styles from "./AlertModal.css";
+
+export type AlertModalProps = {
+  /** 모달 제목  */
+  title?: string;
+
+  /** 모달 설명  */
+  description?: string;
+
+  /** 확인 버튼 클릭 시 실행되는 콜백 */
+  onConfirm?: () => void | Promise<void>;
+
+  /** 취소 버튼 클릭 시 실행되는 콜백 */
+  onCancel?: () => void;
+
+  /** 확인 버튼 텍스트 */
+  confirmLabel?: string;
+
+  /** 취소 버튼 텍스트 */
+  cancelLabel?: string;
+} & DialogProps;
+
+/**
+ * AlertModal 컴포넌트
+ *
+ * @description
+ * Radix UI의 Dialog를 래핑한 모달 컴포넌트입니다.
+ * 제목과 설명을 표시하고, 확인/취소 버튼을 제공합니다.
+ *
+ * @example
+ * ```tsx
+ * const [open, setOpen] = useState(false);
+ *
+ * <AlertModal
+ *   open={open}
+ *   onOpenChange={setOpen}
+ *   title="로그아웃 하시겠어요?"
+ *   description="로그아웃하면 다시 로그인해야 합니다."
+ *   cancelLabel="취소"
+ *   confirmLabel="로그아웃"
+ *   onCancel={() => console.log("취소")}
+ *   onConfirm={() => console.log("확인")}
+ * />
+ * ```
+ */
+export const AlertModal = ({
+  open,
+  onOpenChange,
+  title,
+  description,
+  onConfirm,
+  onCancel,
+  confirmLabel = "확인",
+  cancelLabel = "취소",
+}: AlertModalProps) => {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={styles.overlay} />
+        <Dialog.Content className={styles.content}>
+          {(title || description) && (
+            <div className={styles.textWrapper}>
+              {title && (
+                <Dialog.Title className={styles.title}>{title}</Dialog.Title>
+              )}
+              {description && (
+                <Dialog.Description className={styles.description}>
+                  {description}
+                </Dialog.Description>
+              )}
+            </div>
+          )}
+
+          <div className={styles.buttonGroup}>
+            <Dialog.Close asChild>
+              <Button
+                className={styles.cancelButton}
+                variant='assistive'
+                size='large'
+                onClick={onCancel}
+                style={{
+                  borderRadius: "0 0 0 1.2rem",
+                }}
+              >
+                {cancelLabel}
+              </Button>
+            </Dialog.Close>
+            <Button
+              className={styles.confirmButton}
+              variant='primary'
+              size='large'
+              onClick={onConfirm}
+              style={{
+                borderRadius: "0 0 1.2rem 0",
+              }}
+            >
+              {confirmLabel}
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};

--- a/src/components/ui/AlertModal/index.ts
+++ b/src/components/ui/AlertModal/index.ts
@@ -1,0 +1,1 @@
+export { AlertModal } from "./AlertModal";

--- a/src/components/ui/GNB/GNB.css.ts
+++ b/src/components/ui/GNB/GNB.css.ts
@@ -2,6 +2,7 @@ import { style } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
 
 import { semantic, typography } from "@/styles";
+import { zIndex } from "@/styles/zIndex.css";
 
 export const wrapper = recipe({
   base: {
@@ -12,7 +13,7 @@ export const wrapper = recipe({
     width: "100%",
     height: "5.6rem",
     padding: "1.4rem 2rem",
-    zIndex: 999,
+    zIndex: zIndex.gnb,
   },
   variants: {
     background: {

--- a/src/styles/reset.css.ts
+++ b/src/styles/reset.css.ts
@@ -6,6 +6,10 @@ globalStyle("html", {
   fontSize: "62.5%",
 });
 
+globalStyle("html, body", {
+  height: "100%",
+});
+
 globalStyle(
   "html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video",
   {

--- a/src/styles/zIndex.css.ts
+++ b/src/styles/zIndex.css.ts
@@ -1,0 +1,9 @@
+import { createGlobalTheme } from "@vanilla-extract/css";
+
+export const zIndex = createGlobalTheme(":root", {
+  base: "0",
+  gnb: "100",
+  overlay: "900",
+  modal: "1000",
+  toast: "1100",
+});


### PR DESCRIPTION
## ✅ 이슈 번호

close #87 

<br>

## 🪄 작업 내용 (변경 사항)

- [x] `AlertModal` 컴포넌트 및 스토리북 생성

<br>

## 📸 스크린샷

<br>

## 💡 설명
-  `@radix-ui/react-dialog` 패키지를 사용하여 `AlertModal`을 구현했습니다.
- `src/styles/zIndex.css.ts`에 zIndex 값 상수화하였습니다 😁

<br>

## 🗣️ 리뷰어에게 전달 사항

<br>

## 📍 트러블 슈팅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 확인 또는 취소를 요청하는 AlertModal 컴포넌트가 추가되었습니다.
  * AlertModal 컴포넌트의 스타일이 적용되어 모달의 레이아웃과 버튼 등이 개선되었습니다.
  * AlertModal 컴포넌트의 Storybook 예제가 추가되어 다양한 사용 예시를 확인할 수 있습니다.

* **Style**
  * html 및 body 요소의 높이가 100%로 설정되어 레이아웃 일관성이 향상되었습니다.
  * z-index 값이 전역 테마로 관리되어 UI 레이어의 일관성이 확보되었습니다.
  * GNB의 z-index가 중앙 값으로 변경되어 다른 UI 요소와의 충돌이 방지됩니다.

* **Chores**
  * Radix UI Dialog 라이브러리가 새롭게 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->