### PR TITLE
feat: 마이페이지 로그아웃 API 구현 (#86) 

### DIFF
--- a/src/app/(auth)/_api/auth/auth.queries.ts
+++ b/src/app/(auth)/_api/auth/auth.queries.ts
@@ -30,5 +30,8 @@ export const useReissueMutation = () => {
 export const useDeleteSessionMutation = () => {
   return useMutation({
     mutationFn: deleteClientSession,
+    onSuccess: () => {
+      clearClientSessionCache();
+    },
   });
 };

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+import { getSessionFromServer } from "@/lib/session/serverSession";
+
+export const DELETE = async () => {
+  try {
+    const session = await getSessionFromServer();
+    if (!session.isLoggedIn) {
+      return NextResponse.json(
+        { errorMessage: "세션이 존재하지 않습니다." },
+        { status: 401 }
+      );
+    }
+
+    await session.destroy();
+
+    return NextResponse.json({ message: "로그아웃 완료" }, { status: 200 });
+  } catch (error) {
+    console.error("로그아웃 중 에러:", error);
+    return NextResponse.json(
+      { errorMessage: "로그아웃 처리 중 오류가 발생했습니다." },
+      { status: 500 }
+    );
+  }
+};

--- a/src/app/member/profile/_components/MenuList/MenuList.css.ts
+++ b/src/app/member/profile/_components/MenuList/MenuList.css.ts
@@ -14,3 +14,7 @@ export const menuItem = style({
   ...typography.body1Sb,
   color: semantic.text.normal,
 });
+
+export const modalButton = style({
+  flex: 1,
+});

--- a/src/app/member/profile/_components/MenuList/MenuList.tsx
+++ b/src/app/member/profile/_components/MenuList/MenuList.tsx
@@ -1,13 +1,34 @@
 "use client";
 
+import * as AlertDialog from "@radix-ui/react-alert-dialog";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
+import { useDeleteSessionMutation } from "@/app/(auth)/_api/auth/auth.queries";
+import { AlertModal } from "@/components/ui/AlertModal";
+import { Button } from "@/components/ui/Button";
 import { VStack } from "@/components/ui/Stack";
 
 import { MENU_LIST } from "../../_constants";
 import * as styles from "./MenuList.css";
 
 export const MenuList = () => {
+  const router = useRouter();
+  const { mutate: logout } = useDeleteSessionMutation();
+
+  const handleLogout = () => {
+    logout(undefined, {
+      onSuccess: () => {
+        // TODO: Toast 띄우기
+        router.replace("/");
+      },
+      onError: error => {
+        // TODO: Toast 띄우기
+        console.error("로그아웃 실패", error);
+      },
+    });
+  };
+
   return (
     <>
       <VStack as='ul' gap={8} className={styles.wrapper}>
@@ -18,14 +39,43 @@ export const MenuList = () => {
                 {menu.label}
               </Link>
             ) : (
-              <button type='button' className={styles.menuItem}>
-                {menu.label}
-              </button>
+              <AlertModal
+                title='로그아웃하시나요?'
+                trigger={
+                  <button type='button' className={styles.menuItem}>
+                    로그아웃
+                  </button>
+                }
+                footer={
+                  <>
+                    <AlertDialog.Cancel asChild>
+                      <Button
+                        variant='assistive'
+                        size='large'
+                        className={styles.modalButton}
+                        style={{ borderRadius: "0 0 0 1.2rem" }}
+                      >
+                        취소
+                      </Button>
+                    </AlertDialog.Cancel>
+                    <AlertDialog.Action asChild>
+                      <Button
+                        variant='primary'
+                        size='large'
+                        onClick={handleLogout}
+                        className={styles.modalButton}
+                        style={{ borderRadius: "0 0 1.2rem" }}
+                      >
+                        확인
+                      </Button>
+                    </AlertDialog.Action>
+                  </>
+                }
+              />
             )}
           </li>
         ))}
       </VStack>
-      {/* TODO: 로그아웃시 나타날 모달 연결 */}
     </>
   );
 };

--- a/src/components/ui/AlertModal/AlertModal.css.ts
+++ b/src/components/ui/AlertModal/AlertModal.css.ts
@@ -20,7 +20,7 @@ export const content = style({
   transform: "translate(-50%, -50%)",
   width: "min(30rem, 90vw)",
   background: semantic.background.white,
-  borderRadius: radius[120],
+  borderRadius: radius[160],
   zIndex: zIndex.modal,
 });
 


### PR DESCRIPTION
## ✅ 이슈 번호

close #86

<br>

## 🪄 작업 내용 (변경 사항)

- [x] `/app/api/auth/logout/route.ts` 생성
- [ ] `AlertModal` 디자인 요청사항에 맞게 radius 값 변경

<br>

## 📸 스크린샷

<br>

## 💡 설명

서버 (/api/auth/logout/route.ts)
- getSessionFromServer()로 현재 세션을 확인
- 세션이 없으면 401 반환, 세션이 존재하면 `session.destroy()` 후 200 반환
- 로그아웃 처리 중 에러 발생 시 500 반환

클라이언트 
- useDeleteSessionMutation()으로 DELETE /api/auth/logout 호출 
- onSuccess → `clearClientSessionCache()` 실행 후 router.replace("/")로 메인 페이지 이동
- onError → 추후 Toast 메시지로 에러 안내 예정


<br>

## 🗣️ 리뷰어에게 전달 사항

1. 로그아웃 플로우는 정상 동작하는 것 확인했습니다만, 로직상 더 나은 방식이나 개선할 부분이 있다면 편하게 리뷰 부탁드립니다~! 🙇🏻‍♀️
2. `Toast` 컴포넌트는 구현 후 연결 예정입니다!


<br>

## 📍 트러블 슈팅
