### PR TITLE
feat: 스토리 등록 구현 (#84)

### DIFF
--- a/src/app/(home)/_components/Story/Story.tsx
+++ b/src/app/(home)/_components/Story/Story.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useRef } from "react";
+
+import { useImageUploadContext } from "@/app/story/register/_contexts";
+import { imageFileSchema } from "@/app/story/register/_schemas";
+
+export const Story = () => {
+  const router = useRouter();
+  const { setUpload } = useImageUploadContext();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleOpenPhotoGallery = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const validationResult = imageFileSchema.safeParse(file);
+
+    if (!validationResult.success) {
+      const errorMessage = validationResult.error.errors[0]?.message;
+      // TODO: Toast 변경
+      alert(errorMessage || "올바르지 않은 파일입니다.");
+
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      return;
+    }
+
+    const previewUrl = URL.createObjectURL(file);
+    setUpload(file, previewUrl);
+
+    router.push("/story/register");
+  };
+  return (
+    <>
+      <button onClick={handleOpenPhotoGallery}>스토리 사진 선택</button>
+      <input
+        ref={fileInputRef}
+        type='file'
+        accept='image/jpeg,image/jpg,image/png'
+        onChange={handleFileChange}
+        hidden
+      />
+    </>
+  );
+};

--- a/src/app/(home)/_components/Story/index.ts
+++ b/src/app/(home)/_components/Story/index.ts
@@ -1,0 +1,1 @@
+export { Story } from "./Story";

--- a/src/app/(home)/_components/index.ts
+++ b/src/app/(home)/_components/index.ts
@@ -1,3 +1,4 @@
 export { RecentCheers } from "./RecentCheers";
 export { RecentlySupportedStores } from "./RecentlySupportStories";
 export { StoreStory } from "./StoreStory";
+export { Story } from "./Story";

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,3 +1,11 @@
+"use client";
+
+import Link from "next/link";
+
+import LogoWordmarkIcon from "@/assets/logo-wordmark.svg";
+import { Button } from "@/components/ui/Button";
+import { GNB } from "@/components/ui/GNB";
+
 import * as styles from "./layout.css";
 
 export default function MainLayout({
@@ -5,5 +13,20 @@ export default function MainLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <main className={styles.mainContainer}>{children}</main>;
+  return (
+    <>
+      <GNB
+        leftAddon={<LogoWordmarkIcon width={46} height={24} />}
+        align='left'
+        rightAddon={
+          <Link href='/login'>
+            <Button variant='primary' size='small' style={{ width: "6.3rem" }}>
+              로그인
+            </Button>
+          </Link>
+        }
+      />
+      <main className={styles.mainContainer}>{children}</main>
+    </>
+  );
 }

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { Bleed } from "@/components/ui/Bleed";
 import { Spacer } from "@/components/ui/Spacer";
 import { VStack } from "@/components/ui/Stack";
 
@@ -5,13 +8,16 @@ import {
   RecentCheers,
   RecentlySupportedStores,
   StoreStory,
+  Story,
 } from "./_components";
 
 export default function HomePage() {
   return (
     <>
+      <Bleed inline={20}>
+        <Story />
+      </Bleed>
       <Spacer size={12} />
-      <div>대충 스토리</div>
       <Spacer size={32} />
       <VStack gap={40}>
         <RecentCheers />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { MSWProvider, QueryProvider } from "@/providers";
 import { pretendard } from "@/styles/pretendard";
 
 import * as styles from "./layout.css";
+import { UploadProvider } from "./story/register/_contexts";
 
 export const metadata: Metadata = {
   title: "Eat-da",
@@ -35,7 +36,9 @@ export default function RootLayout({
         <div className={styles.wrapper}>
           <RegisterServiceWorkerClient />
           <QueryProvider>
-            <MSWProvider>{children}</MSWProvider>
+            <MSWProvider>
+              <UploadProvider>{children}</UploadProvider>
+            </MSWProvider>
           </QueryProvider>
         </div>
       </body>

--- a/src/app/story/[id]/page.tsx
+++ b/src/app/story/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function StoryIdPage() {
+  return <div>StoryIdPage</div>;
+}

--- a/src/app/story/register/_api/index.ts
+++ b/src/app/story/register/_api/index.ts
@@ -1,0 +1,3 @@
+export * from "./register.api";
+export * from "./register.queries";
+export * from "./register.types";

--- a/src/app/story/register/_api/register.api.ts
+++ b/src/app/story/register/_api/register.api.ts
@@ -1,0 +1,33 @@
+import { authHttp } from "@/lib/api";
+
+import {
+  type StoryRegisterRequest,
+  type StoryRegisterResponse,
+} from "./register.types";
+
+/**
+ * 스토리 등록 API
+ * @param {StoryRegisterRequest} storyRequest - 스토리 등록 요청 데이터
+ * @param {File} imageFile - 업로드할 이미지 파일
+ *
+ * @returns {Promise<StoryRegisterResponse>} 등록된 스토리 ID 반환
+ */
+export const postStory = async (
+  storyRequest: StoryRegisterRequest,
+  imageFile: File
+): Promise<StoryRegisterResponse> => {
+  const formData = new FormData();
+
+  formData.append(
+    "request",
+    new Blob([JSON.stringify(storyRequest)], { type: "application/json" })
+  );
+
+  formData.append("image", imageFile);
+
+  return await authHttp
+    .post("api/stories", {
+      body: formData,
+    })
+    .json<StoryRegisterResponse>();
+};

--- a/src/app/story/register/_api/register.queries.ts
+++ b/src/app/story/register/_api/register.queries.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { postStory } from "./register.api";
+import type { StoryRegisterRequest } from "./register.types";
+
+export const storyQueryKeys = {
+  all: ["story"] as const,
+  lists: () => [...storyQueryKeys.all, "list"] as const,
+} as const;
+
+export const usePostStoryMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      storyRequest,
+      imageFile,
+    }: {
+      storyRequest: StoryRegisterRequest;
+      imageFile: File;
+    }) => {
+      return postStory(storyRequest, imageFile);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: storyQueryKeys.lists(),
+      });
+    },
+  });
+};

--- a/src/app/story/register/_api/register.types.ts
+++ b/src/app/story/register/_api/register.types.ts
@@ -1,0 +1,9 @@
+export type StoryRegisterRequest = {
+  storeKakaoId: string;
+  storeName: string;
+  description?: string;
+};
+
+export type StoryRegisterResponse = {
+  storyId: number;
+};

--- a/src/app/story/register/_components/StoryDescription/StoryDescription.css.ts
+++ b/src/app/story/register/_components/StoryDescription/StoryDescription.css.ts
@@ -1,0 +1,9 @@
+import { style } from "@vanilla-extract/css";
+
+export const wrapper = style({
+  margin: "2rem 0",
+});
+
+export const textField = style({
+  height: "9.6rem",
+});

--- a/src/app/story/register/_components/StoryDescription/StoryDescription.tsx
+++ b/src/app/story/register/_components/StoryDescription/StoryDescription.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useFormContext } from "react-hook-form";
+
+import { TextField } from "@/components/ui/TextField";
+
+import { type StoryRegisterFormData } from "../../_schemas";
+import * as styles from "./StoryDescription.css";
+
+export const StoryDescription = () => {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<StoryRegisterFormData>();
+
+  return (
+    <div className={styles.wrapper}>
+      <TextField
+        {...register("description")}
+        as='textarea'
+        placeholder='가게에 대해 설명해주세요'
+        status={errors.description ? "negative" : "inactive"}
+        helperText={errors.description?.message}
+        className={styles.textField}
+      />
+    </div>
+  );
+};

--- a/src/app/story/register/_components/StoryDescription/index.ts
+++ b/src/app/story/register/_components/StoryDescription/index.ts
@@ -1,0 +1,1 @@
+export { StoryDescription } from "./StoryDescription";

--- a/src/app/story/register/_components/StoryImagePreview/StoryImagePreview.css.ts
+++ b/src/app/story/register/_components/StoryImagePreview/StoryImagePreview.css.ts
@@ -1,0 +1,35 @@
+import { style } from "@vanilla-extract/css";
+
+import { colors, radius, semantic, typography } from "@/styles";
+
+export const imageWrapper = style({
+  position: "relative",
+  width: "12.1rem",
+  height: "21.3rem",
+  borderRadius: radius[160],
+  overflow: "hidden",
+  margin: "0 auto",
+  backgroundColor: colors.neutral[10],
+});
+
+export const image = style({
+  objectFit: "contain",
+});
+
+export const overlayButtonWrapper = style({
+  position: "absolute",
+  bottom: "0",
+  width: "100%",
+  display: "flex",
+  justifyContent: "center",
+  padding: "0 1.2rem 1.2rem",
+});
+
+export const overlayButton = style({
+  padding: "0.5rem 1.2rem",
+  ...typography.label1Sb,
+  color: semantic.text.white,
+  background: "rgba(23, 23, 23, 0.60)",
+  borderRadius: radius.circle,
+  cursor: "pointer",
+});

--- a/src/app/story/register/_components/StoryImagePreview/StoryImagePreview.tsx
+++ b/src/app/story/register/_components/StoryImagePreview/StoryImagePreview.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Image from "next/image";
+import { useFormContext } from "react-hook-form";
+
+import { imageFileSchema, type StoryRegisterFormData } from "../../_schemas";
+import * as styles from "./StoryImagePreview.css";
+
+export const StoryImagePreview = () => {
+  const { watch, setValue } = useFormContext<StoryRegisterFormData>();
+  const imageFile = watch("image");
+
+  const previewUrl = URL.createObjectURL(imageFile);
+
+  const validateImage = (file: File) => {
+    const result = imageFileSchema.safeParse(file);
+
+    if (!result.success) {
+      const errorMessage = result.error.errors[0]?.message;
+      // TODO: Toast 변경
+      alert(errorMessage);
+      return;
+    }
+
+    setValue("image", file, { shouldValidate: true });
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newFile = e.target.files?.[0];
+
+    if (newFile) {
+      validateImage(newFile);
+    }
+
+    e.target.value = "";
+  };
+
+  return (
+    <div className={styles.imageWrapper}>
+      <Image
+        src={previewUrl}
+        alt='스토리 등록 사진 프리뷰'
+        width={121}
+        height={213}
+        className={styles.image}
+      />
+      <div className={styles.overlayButtonWrapper}>
+        <label className={styles.overlayButton}>
+          사진 변경
+          <input
+            type='file'
+            onChange={handleImageChange}
+            accept='image/jpeg,image/jpg,image/png'
+            hidden
+          />
+        </label>
+      </div>
+    </div>
+  );
+};

--- a/src/app/story/register/_components/StoryImagePreview/index.ts
+++ b/src/app/story/register/_components/StoryImagePreview/index.ts
@@ -1,0 +1,1 @@
+export { StoryImagePreview } from "./StoryImagePreview";

--- a/src/app/story/register/_components/StorySearchStore/StorySearchStore.css.ts
+++ b/src/app/story/register/_components/StorySearchStore/StorySearchStore.css.ts
@@ -1,0 +1,12 @@
+import { style } from "@vanilla-extract/css";
+
+import { colors } from "@/styles";
+
+export const star = style({
+  marginLeft: "0.4rem",
+  color: colors.redOrange[50],
+});
+
+export const field = style({
+  cursor: "pointer",
+});

--- a/src/app/story/register/_components/StorySearchStore/StorySearchStore.tsx
+++ b/src/app/story/register/_components/StorySearchStore/StorySearchStore.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
+
+import { SearchStoreBottomSheet } from "@/app/(search)/_components/SearchStoreBottomSheet";
+import { type SelectedStore } from "@/app/(search)/_types/searchStore.types";
+import SearchIcon from "@/assets/search.svg";
+import { TextField } from "@/components/ui/TextField";
+
+import { type StoryRegisterFormData } from "../../_schemas";
+import * as styles from "./StorySearchStore.css";
+
+export const StorySearchStore = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { register, setValue, watch } = useFormContext<StoryRegisterFormData>();
+
+  const selectedStoreValue = watch("storeName");
+
+  const handleOpenClick = () => {
+    setIsOpen(true);
+  };
+
+  const handleSelectStore = (store: SelectedStore) => {
+    setValue("storeName", store.name, { shouldValidate: true });
+    setValue("storeKakaoId", store.kakaoId, { shouldValidate: true });
+  };
+
+  return (
+    <div>
+      <TextField
+        {...register("storeName", { required: true })}
+        label={
+          <>
+            <span>방문한 가게</span>
+            <span className={styles.star}>*</span>
+          </>
+        }
+        placeholder='가게명을 입력해주세요'
+        value={selectedStoreValue || ""}
+        rightAddon={<SearchIcon width={20} height={20} />}
+        onClick={handleOpenClick}
+        className={styles.field}
+        readOnly
+      />
+      <SearchStoreBottomSheet
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        onSelect={handleSelectStore}
+      />
+    </div>
+  );
+};

--- a/src/app/story/register/_components/StorySearchStore/index.ts
+++ b/src/app/story/register/_components/StorySearchStore/index.ts
@@ -1,0 +1,1 @@
+export { StorySearchStore } from "./StorySearchStore";

--- a/src/app/story/register/_components/StorySubmitButton/StorySubmitButton.tsx
+++ b/src/app/story/register/_components/StorySubmitButton/StorySubmitButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useFormContext, useWatch } from "react-hook-form";
+
+import { Button } from "@/components/ui/Button";
+
+import { type StoryRegisterFormData } from "../../_schemas";
+
+type StorySubmitButtonProps = {
+  isPending?: boolean;
+};
+
+export const StorySubmitButton = ({
+  isPending = false,
+}: StorySubmitButtonProps) => {
+  const {
+    formState: { isValid },
+  } = useFormContext<StoryRegisterFormData>();
+
+  const image = useWatch<StoryRegisterFormData>({ name: "image" });
+  const storeName = useWatch<StoryRegisterFormData>({ name: "storeName" });
+
+  const isDisabled = !image || !storeName || !isValid || isPending;
+
+  return (
+    <Button type='submit' variant='primary' size='large' disabled={isDisabled}>
+      {/* TODO: 스토리 등록 상태 변경 */}
+      {isPending ? "등록 중" : "등록하기"}
+    </Button>
+  );
+};

--- a/src/app/story/register/_components/StorySubmitButton/index.ts
+++ b/src/app/story/register/_components/StorySubmitButton/index.ts
@@ -1,0 +1,1 @@
+export { StorySubmitButton } from "./StorySubmitButton";

--- a/src/app/story/register/_contexts/UploadContext.tsx
+++ b/src/app/story/register/_contexts/UploadContext.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { createContext, type ReactNode, useContext, useState } from "react";
+
+type UploadContextProps = {
+  file?: File;
+  previewUrl?: string;
+  setUpload: (file: File, previewUrl: string) => void;
+  clearUpload: () => void;
+};
+
+const UploadContext = createContext<UploadContextProps | undefined>(undefined);
+
+export const UploadProvider = ({ children }: { children: ReactNode }) => {
+  const [file, setFile] = useState<File | undefined>();
+  const [previewUrl, setPreviewUrl] = useState<string | undefined>();
+
+  const setUpload = (newFile: File, newPreviewUrl: string) => {
+    setFile(newFile);
+    setPreviewUrl(newPreviewUrl);
+  };
+
+  const clearUpload = () => {
+    setFile(undefined);
+    setPreviewUrl(undefined);
+  };
+
+  return (
+    <UploadContext.Provider
+      value={{ file, previewUrl, setUpload, clearUpload }}
+    >
+      {children}
+    </UploadContext.Provider>
+  );
+};
+
+export const useImageUploadContext = () => {
+  const context = useContext(UploadContext);
+  if (!context)
+    throw new Error("useImageUploadContext must be used within UploadProvider");
+  return context;
+};

--- a/src/app/story/register/_contexts/index.ts
+++ b/src/app/story/register/_contexts/index.ts
@@ -1,0 +1,1 @@
+export { UploadProvider, useImageUploadContext } from "./UploadContext";

--- a/src/app/story/register/_schemas/index.ts
+++ b/src/app/story/register/_schemas/index.ts
@@ -1,0 +1,1 @@
+export * from "./storyRegister.schema";

--- a/src/app/story/register/_schemas/storyRegister.schema.ts
+++ b/src/app/story/register/_schemas/storyRegister.schema.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const imageFileSchema = z
+  .instanceof(File)
+  .refine(file => file.size <= 5 * 1024 * 1024, {
+    message: "5MB 이하 사진만 업로드할 수 있어요.",
+  })
+  .refine(
+    file => ["image/jpg", "image/jpeg", "image/png"].includes(file.type),
+    {
+      message: "지원하지 않는 이미지 형식입니다.",
+    }
+  );
+
+export const storyRegisterSchema = z.object({
+  storeKakaoId: z.string().trim(),
+  storeName: z.string().trim(),
+  description: z
+    .string()
+    .max(300, "최대 300자까지 입력할 수 있어요")
+    .trim()
+    .optional(),
+  image: imageFileSchema,
+});
+
+export type StoryRegisterFormData = z.infer<typeof storyRegisterSchema>;

--- a/src/app/story/register/page.css.ts
+++ b/src/app/story/register/page.css.ts
@@ -1,0 +1,11 @@
+import { style } from "@vanilla-extract/css";
+
+export const wrapper = style({
+  width: "100%",
+  height: "100dvh",
+});
+
+export const mainWrapper = style({
+  flex: 1,
+  padding: "2rem",
+});

--- a/src/app/story/register/page.tsx
+++ b/src/app/story/register/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { FormProvider, useForm } from "react-hook-form";
+
+import CancelIcon from "@/assets/cancel.svg";
+import { GNB } from "@/components/ui/GNB";
+import { VStack } from "@/components/ui/Stack";
+
+import { usePostStoryMutation } from "./_api";
+import { StoryDescription } from "./_components/StoryDescription";
+import { StoryImagePreview } from "./_components/StoryImagePreview";
+import { StorySearchStore } from "./_components/StorySearchStore";
+import { StorySubmitButton } from "./_components/StorySubmitButton";
+import { useImageUploadContext } from "./_contexts";
+import { type StoryRegisterFormData, storyRegisterSchema } from "./_schemas";
+import * as styles from "./page.css";
+
+export default function StoryRegisterPage() {
+  const { file, clearUpload } = useImageUploadContext();
+  const router = useRouter();
+  const { mutate: postStory, isPending } = usePostStoryMutation();
+
+  const handleClick = () => {
+    router.back();
+  };
+
+  const methods = useForm<StoryRegisterFormData>({
+    resolver: zodResolver(storyRegisterSchema),
+    defaultValues: {
+      storeKakaoId: "",
+      storeName: "",
+      description: "",
+      image: file,
+    },
+    mode: "onChange",
+  });
+
+  const onSubmit = async (data: StoryRegisterFormData) => {
+    postStory(
+      {
+        storyRequest: {
+          storeKakaoId: data.storeKakaoId,
+          storeName: data.storeName,
+          description: data.description || "",
+        },
+        imageFile: data.image,
+      },
+      {
+        onSuccess: response => {
+          clearUpload();
+          router.push(`/story/${response.storyId}`);
+        },
+        onError: error => {
+          console.error("스토리 등록 실패:", error);
+        },
+      }
+    );
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(onSubmit)}>
+        <VStack justify='between' className={styles.wrapper}>
+          <GNB
+            title='스토리 올리기'
+            rightAddon={
+              <button type='button' onClick={handleClick} aria-label='뒤로가기'>
+                <CancelIcon width={20} height={20} />
+              </button>
+            }
+          />
+          <VStack as='main' justify='between' className={styles.mainWrapper}>
+            <VStack>
+              <StoryImagePreview />
+              <StoryDescription />
+              <StorySearchStore />
+            </VStack>
+            <StorySubmitButton isPending={isPending} />
+          </VStack>
+        </VStack>
+      </form>
+    </FormProvider>
+  );
+}

--- a/src/assets/cancel.svg
+++ b/src/assets/cancel.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 5L5 19" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+<path d="M19 19L5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## ✅ 이슈 번호

close #84

<br>

## 🪄 작업 내용 (변경 사항)

- [x] 스토리 등록 기능 구현
  - [x] 페이지 UI 구현
  - [x] 스토리 등록 API 연동 `/api/stories`

- [x] 이미지 업로드 Context 추가

<br>

## 📸 스크린샷
### 스토리 등록

https://github.com/user-attachments/assets/e5916b7c-cdaa-4c83-ac0b-ece91ee4eb4b

<br>

### 파일 크기가 5MB 넘었을 때

<img width="1200" height="817" alt="스크린샷 2025-07-28 오전 2 42 05" src="https://github.com/user-attachments/assets/34d12a62-c9a2-41c5-8707-4925384781cf" />


<br>

## 💡 설명

### /story/register 페이지 구조: `이미지 → 설명 → 가게 선택` → 제출 버튼

```typescript
<VStack as='main' justify='between' className={styles.mainWrapper}>
  <VStack>
    <StoryImagePreview />    // 이미지 미리보기 & 변경
    <StoryDescription />     // 설명 입력 (선택사항, 300자)
    <StorySearchStore />     // 가게 검색 & 선택, StoreSearchBottomSheet 사용
  </VStack>
  <StorySubmitButton isPending={isPending} />  // 제출 버튼
</VStack>
```

<br>

## 🗣️ 리뷰어에게 전달 사항

### 이미지 싱태 관리 관련

- 전역 Context로 이미지 파일과 미리보기 URL 상태를 관리합니다.
- useImageUploadContext 커스텀 훅으로 접근하며 `홈 → 스토리 등록 페이지` 간 이미지 전달을 위한 목적입니다~!

현재 UploadProvider를 `app/layout.tsx`에서 감싸 전역 범위로 설정해두었습니다.
다만 이미지 공유가 `/ → /story/register` 흐름에서만 사용되기 때문에 라우트 그룹 단위로 범위를 좁히는게 나을지, 아니면 현재처럼 전역 유지가 나을지, 아니면 더 나은 관리 방식이 있다면 의견 공유 부탁드립니다 🍀

<br>

## 📍 트러블 슈팅
