### PR TITLE
bug: 모바일에서 봤을 때 바텀시트 확대 이슈 수정 (#173)

### DIFF
--- a/src/components/ui/BottomSheet/BottomSheetRoot.tsx
+++ b/src/components/ui/BottomSheet/BottomSheetRoot.tsx
@@ -6,7 +6,11 @@ export type BottomSheetRootProps = {
 } & DialogProps;
 
 export function BottomSheetRoot({ children, ...props }: BottomSheetRootProps) {
-  return <Drawer.Root {...props}>{children}</Drawer.Root>;
+  return (
+    <Drawer.Root {...props} repositionInputs={false}>
+      {children}
+    </Drawer.Root>
+  );
 }
 
 BottomSheetRoot.displayName = "BottomSheet.Root";


### PR DESCRIPTION
## ✅ 이슈 번호

close #173

<br>

## 🪄 작업 내용 (변경 사항)

- [x] 모바일에서 봤을 때 바텀시트 확대 이슈 수정

<br>

## 📸 스크린샷

### 수정 전
https://github.com/user-attachments/assets/77fabf61-e2f6-4461-9c81-7009ac6a2101


<br>

## 💡 설명

<br>

## 🗣️ 리뷰어에게 전달 사항

<br>

## 📍 트러블 슈팅
