### PR TITLE
feat: filter bottom sheet, tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@next/third-parties": "^15.4.5",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@suspensive/react": "^3.3.2",
     "@tanstack/react-query": "^5.77.0",
     "@tanstack/react-query-devtools": "^5.77.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@suspensive/react':
         specifier: ^3.3.2
         version: 3.3.2(react@19.1.0)
@@ -164,10 +167,10 @@ importers:
         version: 3.1.4(msw@2.8.4(@types/node@20.17.50)(typescript@5.8.3))(playwright@1.52.0)(vite@6.2.0(@types/node@20.17.50)(jiti@2.4.2)(terser@5.39.2)(yaml@2.8.0))(vitest@3.1.4)
       '@vitest/coverage-v8':
         specifier: ^3.1.4
-        version: 3.1.4(@vitest/browser@3.1.4(msw@2.8.4(@types/node@20.17.50)(typescript@5.8.3))(playwright@1.52.0)(vite@6.2.0(@types/node@20.17.50)(jiti@2.4.2)(terser@5.39.2)(yaml@2.8.0))(vitest@3.1.4))(vitest@3.1.4(@types/node@20.17.50)(@vitest/browser@3.1.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.4(@types/node@20.17.50)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0))
+        version: 3.1.4(@vitest/browser@3.1.4)(vitest@3.1.4)
       '@vitest/eslint-plugin':
         specifier: ^1.2.1
-        version: 1.2.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.1.4(@types/node@20.17.50)(@vitest/browser@3.1.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.4(@types/node@20.17.50)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0))
+        version: 1.2.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.1.4)
       chromatic:
         specifier: ^13.0.1
         version: 13.0.1
@@ -1612,8 +1615,24 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
   '@radix-ui/react-alert-dialog@1.1.14':
     resolution: {integrity: sha512-IOZfZ3nPvN6lXpJTBCunFQPRSvK8MDgSc1FB85xnIpUKOw9en0dJj8JmCAxV7BiZdtYlUpmrQjoTFkVYtdoWzQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1654,6 +1673,15 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.10':
@@ -1726,8 +1754,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1746,6 +1800,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -7745,12 +7812,26 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
   '@radix-ui/react-alert-dialog@1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.5)(react@19.1.0)
       '@radix-ui/react-context': 1.1.2(@types/react@19.1.5)(react@19.1.0)
       '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.5)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.5
+      '@types/react-dom': 19.1.5(@types/react@19.1.5)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.5)(react@19.1.0)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.5)(react@19.1.0)
       react: 19.1.0
@@ -7792,6 +7873,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.5
       '@types/react-dom': 19.1.5(@types/react@19.1.5)
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.1.5)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.5
 
   '@radix-ui/react-dismissable-layer@1.1.10(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -7850,9 +7937,36 @@ snapshots:
       '@types/react': 19.1.5
       '@types/react-dom': 19.1.5(@types/react@19.1.5)
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.5)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.5
+      '@types/react-dom': 19.1.5(@types/react@19.1.5)
+
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.5)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.5
+      '@types/react-dom': 19.1.5(@types/react@19.1.5)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.5)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -7865,6 +7979,22 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.5
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.5)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.1.5(@types/react@19.1.5))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.5)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.5
+      '@types/react-dom': 19.1.5(@types/react@19.1.5)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.5)(react@19.1.0)':
     dependencies:
@@ -8652,7 +8782,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@3.1.4(@vitest/browser@3.1.4(msw@2.8.4(@types/node@20.17.50)(typescript@5.8.3))(playwright@1.52.0)(vite@6.2.0(@types/node@20.17.50)(jiti@2.4.2)(terser@5.39.2)(yaml@2.8.0))(vitest@3.1.4))(vitest@3.1.4(@types/node@20.17.50)(@vitest/browser@3.1.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.4(@types/node@20.17.50)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0))':
+  '@vitest/coverage-v8@3.1.4(@vitest/browser@3.1.4)(vitest@3.1.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -8672,7 +8802,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.2.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.1.4(@types/node@20.17.50)(@vitest/browser@3.1.4)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.8.4(@types/node@20.17.50)(typescript@5.8.3))(terser@5.39.2)(yaml@2.8.0))':
+  '@vitest/eslint-plugin@1.2.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.1.4)':
     dependencies:
       '@typescript-eslint/utils': 8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.27.0(jiti@2.4.2)
@@ -9961,7 +10091,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9983,7 +10113,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.27.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/app/_shared/FilterBottomSheet/FilterBottomSheet.css.ts
+++ b/src/app/_shared/FilterBottomSheet/FilterBottomSheet.css.ts
@@ -1,0 +1,13 @@
+import { style } from "@vanilla-extract/css";
+
+export const bottomSheetContent = style({
+  paddingInline: "2rem",
+});
+
+export const bottomSheetFooter = style({
+  paddingInline: 0,
+});
+
+export const tabsContent = style({
+  minHeight: "36rem",
+});

--- a/src/app/_shared/FilterBottomSheet/FilterBottomSheet.tsx
+++ b/src/app/_shared/FilterBottomSheet/FilterBottomSheet.tsx
@@ -1,0 +1,305 @@
+import { noop } from "es-toolkit";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import { usePreservedCallback } from "react-simplikit";
+
+import { BottomSheet } from "@/components/ui/BottomSheet";
+import { type BottomSheetRootProps } from "@/components/ui/BottomSheet/BottomSheetRoot";
+import { Button } from "@/components/ui/Button";
+import { Chip } from "@/components/ui/Chip";
+import { Spacer } from "@/components/ui/Spacer";
+import { HStack } from "@/components/ui/Stack";
+import { Tabs } from "@/components/ui/Tabs";
+import { LOCATIONS } from "@/constants/location.constants";
+import { ATMOSPHERE_TAGS, UTILITY_TAGS } from "@/constants/tag.constants";
+
+import * as styles from "./FilterBottomSheet.css";
+
+export type FilterValues = {
+  locations: string[];
+  atmosphereTags: string[];
+  utilityTags: string[];
+};
+
+export type FilterBottomSheetProps = {
+  /**
+   * 필터 적용 시 호출되는 콜백 ("결과 보기" 버튼 클릭 또는 바텀시트 닫힐 때)
+   */
+  onApply?: (filters: FilterValues) => void;
+  /**
+   * 초기 선택된 필터 값들
+   */
+  defaultValues?: FilterValues;
+  /**
+   * 실시간 필터 변경 시 호출되는 콜백 (제공되면 자동으로 실시간 업데이트 활성화)
+   */
+  onChange?: (filters: FilterValues) => void;
+} & Omit<BottomSheetRootProps, "children">;
+
+/**
+ * 필터 바텀시트
+ *
+ * 지역, 분위기, 실용도별로 다중 선택이 가능한 필터 바텀시트입니다.
+ * 기본적으로는 "결과 보기" 버튼 클릭 시 필터가 적용되며,
+ * onChange 콜백을 제공하면 실시간으로 필터 변경사항을 추적할 수 있습니다.
+ *
+ * @example
+ * ```tsx
+ * // 기본 사용법 (배치 적용)
+ * <FilterBottomSheet
+ *   open={isOpen}
+ *   onOpenChange={setIsOpen}
+ *   onApply={setFilters}
+ *   defaultValues={{
+ *     locations: ["GANGNAM"],
+ *     atmosphereTags: ["OLD_STORE_MOOD"],
+ *     utilityTags: ["GROUP_RESERVATION"],
+ *   }}
+ * />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Overlay 패턴과 함께 사용
+ * <button
+ *   onClick={async () => {
+ *     const result = await overlay.openAsync(({ isOpen, close }) => {
+ *       return (
+ *         <FilterBottomSheet
+ *           open={isOpen}
+ *           onOpenChange={close}
+ *           onApply={close}
+ *           defaultValues={{
+ *             locations: ["GANGNAM"],
+ *             atmosphereTags: ["OLD_STORE_MOOD"],
+ *             utilityTags: ["GROUP_RESERVATION"],
+ *           }}
+ *         />
+ *       );
+ *     });
+ *     console.log(result);
+ *   }}
+ * >
+ *   필터 열기
+ * </button>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // 실시간 업데이트 방식
+ * const [resultCount, setResultCount] = useState(0);
+ *
+ * return (
+ *   <FilterBottomSheet
+ *     open={isOpen}
+ *     onOpenChange={setIsOpen}
+ *     onApply={setFilters}
+ *     onChange={async (filters) => {
+ *       // 필터 변경될 때마다 즉시 호출됨
+ *       const count = await getFilteredStoreCount(filters);
+ *       setResultCount(count);
+ *     }}
+ *   />
+ * );
+ * ```
+ */
+export const FilterBottomSheet = ({
+  open,
+  onOpenChange,
+  onApply,
+  defaultValues,
+  onChange,
+}: FilterBottomSheetProps) => {
+  const [selectedLocations, setSelectedLocations] = useState<string[]>(
+    defaultValues?.locations ?? []
+  );
+  const [selectedAtmosphereTags, setSelectedAtmosphereTags] = useState<
+    string[]
+  >(defaultValues?.atmosphereTags ?? []);
+  const [selectedUtilityTags, setSelectedUtilityTags] = useState<string[]>(
+    defaultValues?.utilityTags ?? []
+  );
+
+  const onChangeCallback = usePreservedCallback(onChange ?? noop);
+  const hasOnChange = !!onChange;
+
+  useEffect(() => {
+    if (!hasOnChange) {
+      return;
+    }
+
+    const filters: FilterValues = {
+      locations: selectedLocations,
+      atmosphereTags: selectedAtmosphereTags,
+      utilityTags: selectedUtilityTags,
+    };
+
+    onChangeCallback(filters);
+  }, [
+    hasOnChange,
+    onChangeCallback,
+    selectedAtmosphereTags,
+    selectedLocations,
+    selectedUtilityTags,
+  ]);
+
+  const handleReset = () => {
+    setSelectedLocations([]);
+    setSelectedAtmosphereTags([]);
+    setSelectedUtilityTags([]);
+  };
+
+  const handleApplyFilters = () => {
+    const filters: FilterValues = {
+      locations: selectedLocations,
+      atmosphereTags: selectedAtmosphereTags,
+      utilityTags: selectedUtilityTags,
+    };
+    onApply?.(filters);
+    onOpenChange?.(false);
+  };
+
+  return (
+    <BottomSheet.Root
+      open={open}
+      onOpenChange={opened => {
+        if (!opened) {
+          handleApplyFilters();
+          return;
+        }
+        onOpenChange?.(opened);
+      }}
+    >
+      <BottomSheet.Content className={styles.bottomSheetContent}>
+        <BottomSheet.Title>
+          <></>
+        </BottomSheet.Title>
+        <Tabs.Root defaultValue='location'>
+          <Tabs.List>
+            <Tabs.Trigger value='location'>지역</Tabs.Trigger>
+            <Tabs.Trigger value='mood'>분위기</Tabs.Trigger>
+            <Tabs.Trigger value='utility'>실용도</Tabs.Trigger>
+          </Tabs.List>
+          <Spacer size={20} />
+          <Tabs.Content value='location' className={styles.tabsContent}>
+            <LocationTab
+              selectedValues={selectedLocations}
+              onSelectionChange={setSelectedLocations}
+            />
+          </Tabs.Content>
+          <Tabs.Content value='mood' className={styles.tabsContent}>
+            <MoodTab
+              selectedValues={selectedAtmosphereTags}
+              onSelectionChange={setSelectedAtmosphereTags}
+            />
+          </Tabs.Content>
+          <Tabs.Content value='utility' className={styles.tabsContent}>
+            <UtilityTab
+              selectedValues={selectedUtilityTags}
+              onSelectionChange={setSelectedUtilityTags}
+            />
+          </Tabs.Content>
+        </Tabs.Root>
+        <BottomSheet.Footer className={styles.bottomSheetFooter}>
+          <HStack gap={8}>
+            <Button
+              variant='assistive'
+              size='fullWidth'
+              style={{ width: "auto" }}
+              onClick={handleReset}
+            >
+              초기화
+            </Button>
+            <Button size='fullWidth' onClick={handleApplyFilters}>
+              결과 보기
+            </Button>
+          </HStack>
+        </BottomSheet.Footer>
+      </BottomSheet.Content>
+    </BottomSheet.Root>
+  );
+};
+
+type FilterTabProps = {
+  selectedValues: string[];
+  onSelectionChange: (values: string[]) => void;
+};
+
+const LocationTab = ({ selectedValues, onSelectionChange }: FilterTabProps) => {
+  const handleLocationToggle = (locationValue: string) => {
+    const isSelected = selectedValues.includes(locationValue);
+    if (isSelected) {
+      onSelectionChange(
+        selectedValues.filter(value => value !== locationValue)
+      );
+    } else {
+      onSelectionChange([...selectedValues, locationValue]);
+    }
+  };
+
+  return (
+    <HStack wrap='wrap' gap='1.2rem 0.8rem '>
+      {LOCATIONS.map(location => (
+        <Chip
+          key={location.value}
+          active={selectedValues.includes(location.value)}
+          onClick={() => handleLocationToggle(location.value)}
+        >
+          {location.label}
+        </Chip>
+      ))}
+    </HStack>
+  );
+};
+
+const MoodTab = ({ selectedValues, onSelectionChange }: FilterTabProps) => {
+  const handleTagToggle = (tagName: string) => {
+    const isSelected = selectedValues.includes(tagName);
+    if (isSelected) {
+      onSelectionChange(selectedValues.filter(value => value !== tagName));
+    } else {
+      onSelectionChange([...selectedValues, tagName]);
+    }
+  };
+
+  return (
+    <HStack wrap='wrap' gap='1.2rem 0.8rem '>
+      {ATMOSPHERE_TAGS.map(tag => (
+        <Chip
+          key={tag.name}
+          active={selectedValues.includes(tag.name)}
+          onClick={() => handleTagToggle(tag.name)}
+        >
+          <Image src={tag.iconUrl} alt={tag.label} width={16} height={16} />
+          {tag.label}
+        </Chip>
+      ))}
+    </HStack>
+  );
+};
+
+const UtilityTab = ({ selectedValues, onSelectionChange }: FilterTabProps) => {
+  const handleTagToggle = (tagName: string) => {
+    const isSelected = selectedValues.includes(tagName);
+    if (isSelected) {
+      onSelectionChange(selectedValues.filter(value => value !== tagName));
+    } else {
+      onSelectionChange([...selectedValues, tagName]);
+    }
+  };
+
+  return (
+    <HStack wrap='wrap' gap='1.2rem 0.8rem '>
+      {UTILITY_TAGS.map(tag => (
+        <Chip
+          key={tag.name}
+          active={selectedValues.includes(tag.name)}
+          onClick={() => handleTagToggle(tag.name)}
+        >
+          <Image src={tag.iconUrl} alt={tag.label} width={16} height={16} />
+          {tag.label}
+        </Chip>
+      ))}
+    </HStack>
+  );
+};

--- a/src/app/_shared/FilterBottomSheet/index.ts
+++ b/src/app/_shared/FilterBottomSheet/index.ts
@@ -1,0 +1,5 @@
+export {
+  FilterBottomSheet,
+  type FilterBottomSheetProps,
+  type FilterValues,
+} from "./FilterBottomSheet";

--- a/src/components/ui/Chip/Chip.tsx
+++ b/src/components/ui/Chip/Chip.tsx
@@ -9,7 +9,10 @@ export type ChipProps = {
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 export const Chip = forwardRef<HTMLButtonElement, ChipProps>(
-  ({ children, size = "medium", active, className, ...restProps }, ref) => {
+  (
+    { children, size = "medium", active = false, className, ...restProps },
+    ref
+  ) => {
     return (
       <button
         className={clsx(chip({ size, active }), className)}

--- a/src/components/ui/Tabs/Tabs.css.ts
+++ b/src/components/ui/Tabs/Tabs.css.ts
@@ -1,0 +1,58 @@
+import { recipe } from "@vanilla-extract/recipes";
+
+import { colors, semantic } from "@/styles";
+
+export const tabsList = recipe({
+  base: {
+    display: "flex",
+  },
+  variants: {
+    layout: {
+      content: {
+        gap: "2.4rem",
+      },
+      equal: {
+        gap: 0,
+      },
+    },
+  },
+  defaultVariants: {
+    layout: "content",
+  },
+});
+
+export const tabsTrigger = recipe({
+  base: {
+    paddingBlock: "1.2rem",
+    position: "relative",
+    selectors: {
+      "&[data-state='active']": {
+        color: semantic.text.normal,
+      },
+      "&[data-state='inactive']": {
+        color: colors.coolNeutral[80],
+      },
+      "&[data-state='active']::after": {
+        content: "''",
+        position: "absolute",
+        bottom: 0,
+        left: 0,
+        right: 0,
+        height: "2px",
+        backgroundColor: colors.neutral[10],
+      },
+    },
+  },
+  variants: {
+    layout: {
+      content: {},
+      equal: {
+        flex: 1,
+        borderBottom: `1px solid ${colors.coolNeutral[90]}`,
+      },
+    },
+  },
+  defaultVariants: {
+    layout: "content",
+  },
+});

--- a/src/components/ui/Tabs/Tabs.stories.tsx
+++ b/src/components/ui/Tabs/Tabs.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+import { Tabs } from "./Tabs";
+
+const meta: Meta<typeof Tabs.Root> = {
+  title: "Components/Tabs",
+  component: Tabs.Root,
+  tags: ["autodocs"],
+  argTypes: {
+    triggerLayout: {
+      control: { type: "radio" },
+      options: ["content", "equal"],
+      description: "트리거의 레이아웃 방식을 설정합니다.",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Tabs는 탭 메뉴를 구현할 때 사용합니다. triggerLayout prop으로 트리거의 레이아웃을 제어할 수 있습니다.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Tabs.Root>;
+
+export const Default: Story = {
+  args: {
+    defaultValue: "tab1",
+    triggerLayout: "content",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "기본 탭 컴포넌트입니다. triggerLayout을 'content'로 설정하면 트리거가 컨텐츠 크기만큼 차지하고 사이에 gap이 있습니다.",
+      },
+    },
+  },
+  render: args => (
+    <Tabs.Root {...args}>
+      <Tabs.List>
+        <Tabs.Trigger value='tab1'>Tab 1</Tabs.Trigger>
+        <Tabs.Trigger value='tab2'>Tab 2</Tabs.Trigger>
+        <Tabs.Trigger value='tab3'>Tab 3</Tabs.Trigger>
+      </Tabs.List>
+    </Tabs.Root>
+  ),
+};
+
+export const EqualLayout: Story = {
+  args: {
+    defaultValue: "tab1",
+    triggerLayout: "equal",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "triggerLayout을 'equal'로 설정하면 트리거들이 균등하게 분할되어 gap 없이 전체 너비를 차지합니다.",
+      },
+    },
+  },
+  render: args => (
+    <Tabs.Root {...args}>
+      <Tabs.List>
+        <Tabs.Trigger value='tab1'>Short</Tabs.Trigger>
+        <Tabs.Trigger value='tab2'>Medium Tab</Tabs.Trigger>
+        <Tabs.Trigger value='tab3'>Very Long Tab Name</Tabs.Trigger>
+      </Tabs.List>
+    </Tabs.Root>
+  ),
+};

--- a/src/components/ui/Tabs/Tabs.tsx
+++ b/src/components/ui/Tabs/Tabs.tsx
@@ -1,0 +1,68 @@
+import * as RadixTabs from "@radix-ui/react-tabs";
+import { type ComponentRef, forwardRef } from "react";
+
+import { Text } from "../Text";
+import { TabsProvider, useTabs } from "./context";
+import * as styles from "./Tabs.css";
+
+type TabsRootProps = {
+  triggerLayout?: "content" | "equal";
+} & RadixTabs.TabsProps;
+
+const TabsRoot = forwardRef<ComponentRef<typeof RadixTabs.Root>, TabsRootProps>(
+  ({ triggerLayout = "content", ...props }, ref) => {
+    return (
+      <TabsProvider triggerLayout={triggerLayout}>
+        <RadixTabs.Root {...props} ref={ref} />
+      </TabsProvider>
+    );
+  }
+);
+TabsRoot.displayName = "TabsRoot";
+
+const TabsList = forwardRef<
+  ComponentRef<typeof RadixTabs.List>,
+  RadixTabs.TabsListProps
+>((props, ref) => {
+  const { triggerLayout } = useTabs();
+
+  return (
+    <RadixTabs.List
+      {...props}
+      ref={ref}
+      className={styles.tabsList({ layout: triggerLayout })}
+    />
+  );
+});
+TabsList.displayName = "TabsList";
+
+const TabsTrigger = forwardRef<
+  ComponentRef<typeof RadixTabs.Trigger>,
+  RadixTabs.TabsTriggerProps
+>((props, ref) => {
+  const { triggerLayout } = useTabs();
+
+  return (
+    <RadixTabs.Trigger
+      {...props}
+      asChild
+      ref={ref}
+      className={styles.tabsTrigger({ layout: triggerLayout })}
+    >
+      <Text as='button' typo='body1Sb'>
+        {props.children}
+      </Text>
+    </RadixTabs.Trigger>
+  );
+});
+
+TabsTrigger.displayName = "TabsTrigger";
+
+const TabsContent = RadixTabs.Content;
+
+export const Tabs = {
+  Root: TabsRoot,
+  List: TabsList,
+  Trigger: TabsTrigger,
+  Content: TabsContent,
+};

--- a/src/components/ui/Tabs/context.ts
+++ b/src/components/ui/Tabs/context.ts
@@ -1,0 +1,5 @@
+import { buildContext } from "react-simplikit";
+
+export const [TabsProvider, useTabs] = buildContext<{
+  triggerLayout: "content" | "equal";
+}>("Tabs");

--- a/src/components/ui/Tabs/index.ts
+++ b/src/components/ui/Tabs/index.ts
@@ -1,0 +1,1 @@
+export * from "./Tabs";

--- a/src/constants/location.constants.ts
+++ b/src/constants/location.constants.ts
@@ -1,0 +1,79 @@
+import { type Location } from "@/types/location";
+
+export const LOCATIONS: Location[] = [
+  {
+    value: "GANGNAM",
+    label: "강남/역삼/선릉",
+    districts: ["강남구"],
+  },
+  {
+    value: "KONDAE",
+    label: "건대/성수/서울숲/왕십리",
+    districts: ["성동구", "광진구"],
+  },
+  {
+    value: "GEUMHO",
+    label: "금호/옥수/신당",
+    districts: ["중구"],
+  },
+  {
+    value: "HAPJEONG",
+    label: "합정/망원/홍대",
+    districts: ["마포구"],
+  },
+  {
+    value: "SINCHON",
+    label: "신촌/이대",
+    districts: ["서대문구"],
+  },
+  {
+    value: "MYEONGDONG",
+    label: "명동/을지로/충무로",
+    districts: ["동대문구", "성북구"],
+  },
+  {
+    value: "SEOCHON",
+    label: "서촌/북촌/삼청",
+    districts: ["종로구"],
+  },
+  {
+    value: "DAECHI",
+    label: "대치/논현/서초",
+    districts: ["서초구"],
+  },
+  {
+    value: "YONGSAN",
+    label: "용산/이태원/한남",
+    districts: ["용산구", "동작구"],
+  },
+  {
+    value: "GEUMCHEON",
+    label: "금천/도봉/노원",
+    districts: ["금천구", "도봉구", "노원구"],
+  },
+  {
+    value: "YEONGDEUNGPO",
+    label: "영등포/여의도",
+    districts: ["영등포구"],
+  },
+  {
+    value: "JAMSIL",
+    label: "잠실/송파",
+    districts: ["송파구"],
+  },
+  {
+    value: "JONGRO",
+    label: "종로/광화문",
+    districts: ["종로구"],
+  },
+  {
+    value: "MAGOK",
+    label: "마곡/목동/강서",
+    districts: ["강서구", "양천구"],
+  },
+  {
+    value: "GURO",
+    label: "구로/서울대입구",
+    districts: ["구로구", "관악구"],
+  },
+];

--- a/src/constants/tag.constants.ts
+++ b/src/constants/tag.constants.ts
@@ -12,9 +12,9 @@ export const ATMOSPHERE_TAGS: Tag[] = [
     label: "활기찬",
   },
   {
-    iconUrl: "/images/tags/INSTAGRAMMABLE.png",
-    name: "INSTAGRAMMABLE",
-    label: "인스타 감성",
+    iconUrl: "/images/tags/GOOD_FOR_DATING.png",
+    name: "GOOD_FOR_DATING",
+    label: "데이트하기 좋은",
   },
   {
     iconUrl: "/images/tags/QUIET.png",
@@ -27,9 +27,9 @@ export const ATMOSPHERE_TAGS: Tag[] = [
     label: "술 땡기는",
   },
   {
-    iconUrl: "/images/tags/GOOD_FOR_DATING.png",
-    name: "GOOD_FOR_DATING",
-    label: "데이트하기 좋은",
+    iconUrl: "/images/tags/INSTAGRAMMABLE.png",
+    name: "INSTAGRAMMABLE",
+    label: "인스타 감성",
   },
   {
     iconUrl: "/images/tags/GOOD_FOR_FAMILY.png",

--- a/src/types/location.ts
+++ b/src/types/location.ts
@@ -1,0 +1,17 @@
+export type Location = {
+  /**
+   * 지역 고유 값
+   * @example "GANGNAM"
+   */
+  value: string;
+  /**
+   * 지역 이름
+   * @example "강남/역삼/선릉"
+   */
+  label: string;
+  /**
+   * 해당 지역에 속하는 구 목록
+   * @example ["강남구", "성동구", "광진구"]
+   */
+  districts: string[];
+};


### PR DESCRIPTION
## ✅ 이슈 번호

close x

<br>

## 🪄 작업 내용 (변경 사항)

- [x] tabs 추가
- [x] locations 상수 추가
- [x] filter bottom sheet 추가

<br>

## 📸 스크린샷
<img width="982" height="1876" alt="6737" src="https://github.com/user-attachments/assets/62b26734-55af-4a5a-a8ba-42831dc17c70" />

<br>

## 💡 설명

<br>

## 🗣️ 리뷰어에게 전달 사항

쓰으으읍 진짜 끝나고 폴더 구조부터 , , 

<br>

## 📍 트러블 슈팅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 필터 바텀시트 추가: 위치/무드/유틸리티 탭으로 빠른 필터링, 초기화·적용 지원
  - 새 탭 컴포넌트 도입: 콘텐츠/균등 레이아웃 선택 가능
- Style
  - 바텀시트와 탭 스타일 추가로 가독성과 사용성 향상
- Content
  - 지역 목록 데이터 추가(서울 주요 권역) 및 무드 태그 순서 조정
- Documentation
  - 탭 스토리북 스토리 추가(예시와 레이아웃 데모)
- Chores
  - 탭 UI 라이브러리 의존성 추가
- Refactor
  - Chip 기본 활성 상태 명시로 일관성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->