### PR TITLE
refactor: 스토리 페이지 이미지 등록 방식 변경 (#149)

### DIFF
--- a/src/app/(home)/_components/Story/StoryList/StoryList.css.ts
+++ b/src/app/(home)/_components/Story/StoryList/StoryList.css.ts
@@ -19,5 +19,6 @@ export const storyImageInner = style({
 export const storyImage = style({
   display: "block",
   borderRadius: radius.circle,
+  objectFit: "cover",
   cursor: "pointer",
 });

--- a/src/app/(home)/_components/Story/StoryList/StoryList.tsx
+++ b/src/app/(home)/_components/Story/StoryList/StoryList.tsx
@@ -27,12 +27,11 @@ export const StoryList = () => {
         >
           <div className={styles.storyImageInner}>
             <Image
-              src={story.imageUrl}
+              src={story.images?.[0]?.url ?? ""}
               width={80}
               height={80}
               alt={`스토리 이미지 ${story.storyId}`}
               className={styles.storyImage}
-              objectFit='cover'
               // TODO: 추후 제거
               unoptimized
             />

--- a/src/app/(store)/stores/[storeId]/_components/StoreStories/StoreStories.tsx
+++ b/src/app/(store)/stores/[storeId]/_components/StoreStories/StoreStories.tsx
@@ -68,7 +68,7 @@ const StoreStoriesContent = ({ kakaoId }: { kakaoId: string }) => {
           <Link href={`/story/${data.storyId}`} key={data.storyId}>
             <div className={styles.storyWrapper}>
               <Image
-                src={data.imageUrl}
+                src={data.images?.[0]?.url ?? ""}
                 alt='스토리 이미지'
                 className={styles.image}
                 width={124}

--- a/src/app/story/[id]/_api/detail.types.ts
+++ b/src/app/story/[id]/_api/detail.types.ts
@@ -1,3 +1,5 @@
+import type { ImageResponse } from "@/types";
+
 export type StoryDetailResponse = {
   storeKakaoId: string;
   category: string;
@@ -5,7 +7,7 @@ export type StoryDetailResponse = {
   storeDistrict: string;
   storeNeighborhood: string;
   description: string | null;
-  imageUrl: string;
+  images: ImageResponse[];
   memberId: number;
   memberNickname: string;
   storeId: number | null;

--- a/src/app/story/[id]/_components/StoryDetailContent/StoryDetailContent.tsx
+++ b/src/app/story/[id]/_components/StoryDetailContent/StoryDetailContent.tsx
@@ -90,7 +90,7 @@ export const StoryDetailContent = ({ storyId }: StoryDetailContentProps) => {
           onClick={handleNextStory}
         />
         <Image
-          src={story.imageUrl}
+          src={story.images?.[0]?.url ?? ""}
           alt={`${story.storeName} 스토리`}
           fill
           priority

--- a/src/app/story/_api/stories.types.ts
+++ b/src/app/story/_api/stories.types.ts
@@ -1,6 +1,8 @@
+import { type ImageResponse } from "@/types";
+
 export type Story = {
   storyId: number;
-  imageUrl: string;
+  images: ImageResponse[];
 };
 
 export type StoriesResponse = {
@@ -9,7 +11,7 @@ export type StoriesResponse = {
 
 export type StoryByKakaoId = {
   storyId: number;
-  imageUrl: string;
+  images: ImageResponse[];
   memberId: number;
   memberNickname: string;
 };

--- a/src/app/story/register/_api/register.api.ts
+++ b/src/app/story/register/_api/register.api.ts
@@ -8,26 +8,15 @@ import {
 /**
  * 스토리 등록 API
  * @param {StoryRegisterRequest} storyRequest - 스토리 등록 요청 데이터
- * @param {File} imageFile - 업로드할 이미지 파일
  *
  * @returns {Promise<StoryRegisterResponse>} 등록된 스토리 ID 반환
  */
 export const postStory = async (
-  storyRequest: StoryRegisterRequest,
-  imageFile: File
+  storyRequest: StoryRegisterRequest
 ): Promise<StoryRegisterResponse> => {
-  const formData = new FormData();
-
-  formData.append(
-    "request",
-    new Blob([JSON.stringify(storyRequest)], { type: "application/json" })
-  );
-
-  formData.append("image", imageFile);
-
   return await authHttp
     .post("api/stories", {
-      body: formData,
+      json: storyRequest,
     })
     .json<StoryRegisterResponse>();
 };

--- a/src/app/story/register/_api/register.queries.ts
+++ b/src/app/story/register/_api/register.queries.ts
@@ -2,21 +2,12 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { storiesQueryKeys } from "../../_api";
 import { postStory } from "./register.api";
-import type { StoryRegisterRequest } from "./register.types";
 
 export const usePostStoryMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({
-      storyRequest,
-      imageFile,
-    }: {
-      storyRequest: StoryRegisterRequest;
-      imageFile: File;
-    }) => {
-      return postStory(storyRequest, imageFile);
-    },
+    mutationFn: postStory,
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: storiesQueryKeys.lists(),

--- a/src/app/story/register/_api/register.types.ts
+++ b/src/app/story/register/_api/register.types.ts
@@ -1,7 +1,10 @@
+import { type ImageRequest } from "@/types";
+
 export type StoryRegisterRequest = {
   storeKakaoId: string;
   storeName: string;
   description: string | null;
+  images: ImageRequest[];
 };
 
 export type StoryRegisterResponse = {

--- a/src/types/image.types.ts
+++ b/src/types/image.types.ts
@@ -1,0 +1,11 @@
+export type ImageMeta = {
+  imageKey: string;
+  orderIndex: number;
+  contentType: string;
+  fileSize: number;
+  url: string;
+};
+
+export type ImageRequest = Omit<ImageMeta, "url">;
+
+export type ImageResponse = ImageMeta;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from "./image.types";


### PR DESCRIPTION
## ✅ 이슈 번호

close #149 

<br>

## 🪄 작업 내용 (변경 사항)

- [x] 스토리 페이지 이미지 등록 방식 변경
- [x] 스토리 이미지 응답값 변경

<br>

## 📸 스크린샷

<br>

## 💡 설명

스토리 이미지 등록 로직을 `FormData` 형식에서 `presigned URL` 방식으로 전환하였습니다!

**src/types/image.types.ts**
- 요청 시 사용할 `ImageRequest`와 응답 시 사용할 `ImageResponse` 타입을 분리하여 정의했습니다. 


<br>

## 🗣️ 리뷰어에게 전달 사항

<br>

## 📍 트러블 슈팅
