### PR TITLE
fix: X-Origin-Verify 헤더를 환경 변수로 변경

### DIFF
--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -70,8 +70,7 @@ export const http = ky.create({
   prefixUrl: API_BASE_URL,
   headers: {
     ...(isServer() && {
-      "X-Origin-Verify":
-        "e8eb093eeaf23930588ac65b94972d477345d3b8821197dfbcce84c223c9b6b3",
+      "X-Origin-Verify": process.env.ORIGIN_VERIFY,
     }),
   },
   hooks: {


### PR DESCRIPTION
## ✅ 이슈 번호

close x

<br>

## 🪄 작업 내용 (변경 사항)

- [x] X-Origin-Verify 헤더를 환경 변수로 변경

<br>

## 📸 스크린샷

<br>

## 💡 설명

기존 해시 무효화, 환경변수로 주입 받도록 변경합니다.

<br>

## 🗣️ 리뷰어에게 전달 사항

<br>

## 📍 트러블 슈팅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 서버 실행 시 구성 값을 환경에서 주입하도록 업데이트하여 배포 환경별 설정 관리가 간편해지고 보안성이 향상되었습니다.
  * 하드코딩 의존도를 줄여 운영/스테이징 등 환경별로 일관된 설정 적용이 가능합니다.
  * 사용자 기능 변화나 공개 API 변경은 없으며, 앱 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->